### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: Reef Client
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Install
+      run: npm install
+    - name: Build
+      run: npm run build
+    # Source code doesn't meet the linter requirements.
+    # Once it will be resolved, we could uncomment the 'lint' step.
+    # - name: Lint
+    #   run: npm run lint


### PR DESCRIPTION
I would like to propose adding GitHub Actions workflow.
Example Run: https://github.com/mwarzynski/reef-client/actions/runs/702840521

Workflow checks if state of the source code allows to successfully build the project. It's triggered for every push to the repository.

What do you think about adjusting the code accordingly to the defined linter rules? Currently, if we run the linter, it will return errors (at least it didn't pass for `npm run lint`).
I also would like to propose adding a requirement to the PR for a successful build (if my PR will be merged).